### PR TITLE
Make trailers ordinal

### DIFF
--- a/src/trailer.rs
+++ b/src/trailer.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use thiserror::Error;
 
 /// A `Trailer` you might see a in a `CommitMessage`, for example 'Co-authored-by: Billie Thompson <billie@example.com>'
-#[derive(Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash, Ord, PartialOrd)]
 pub struct Trailer {
     key: String,
     value: String,


### PR DESCRIPTION
It's nice to have the trailers printed out in a predictable order in
other to make tests easier, but it's also kinda visually nice.
