### PR TITLE
fix: Ignore trailing newlines in trailers for comparisons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 ## Format what can be formatted
 fmt:
 	cargo fix --allow-dirty
-	cargo clippy --allow-dirty --fix -Z unstable-options --all-features -- -D warnings -Dclippy::all -D clippy::pedantic
+	cargo +nightly clippy --allow-dirty --fix -Z unstable-options --all-features -- -D warnings -Dclippy::all -D clippy::pedantic
 	cargo fmt --all
 	npx prettier --write **.yml
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-unstable_features = true
-format_code_in_doc_comments = true


### PR DESCRIPTION
These are added back in anyway, so it's a bit redundant.

Fixes PurpleBooth/git-mit#345
