### PR TITLE
fix: conventional commits should not be detected as trailers

### DIFF
--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -174,6 +174,7 @@ impl<'a> From<Vec<Fragment<'a>>> for Bodies<'a> {
         let trailer_count = raw_body
             .clone()
             .into_iter()
+            .skip(1)
             .rev()
             .take_while(|body| body.is_empty() || Trailer::try_from(body.clone()).is_ok())
             .count();

--- a/src/commit_message_test.rs
+++ b/src/commit_message_test.rs
@@ -139,6 +139,51 @@ fn can_add_trailers_to_a_normal_commit() {
 }
 
 #[test]
+fn can_add_trailers_to_a_conventional_commit() {
+    let commit = CommitMessage::from(indoc!(
+            "
+            feat: Example Commit Message
+
+            This is an example commit message for linting
+
+            # Bitte geben Sie eine Commit-Beschreibung f\u{00FC}r Ihre \u{00E4}nderungen ein. Zeilen,
+            # die mit '#' beginnen, werden ignoriert, und eine leere Beschreibung
+            # bricht den Commit ab.
+            #
+            # Auf Branch main
+            # Ihr Branch ist auf demselben Stand wie 'origin/main'.
+            #
+            # Zum Commit vorgemerkte \u{00E4}nderungen:
+            #	neue Datei:     file
+            #
+            "
+        ));
+
+    assert_eq!(
+        String::from(commit.add_trailer(Trailer::new("Co-authored-by".into(), "Test Trailer <test@example.com>".into()))),
+        String::from(CommitMessage::from(indoc!(
+            "
+            feat: Example Commit Message
+
+            This is an example commit message for linting
+
+            Co-authored-by: Test Trailer <test@example.com>
+
+            # Bitte geben Sie eine Commit-Beschreibung f\u{00FC}r Ihre \u{00E4}nderungen ein. Zeilen,
+            # die mit '#' beginnen, werden ignoriert, und eine leere Beschreibung
+            # bricht den Commit ab.
+            #
+            # Auf Branch main
+            # Ihr Branch ist auf demselben Stand wie 'origin/main'.
+            #
+            # Zum Commit vorgemerkte \u{00E4}nderungen:
+            #	neue Datei:     file
+            #
+            "
+        ))));
+}
+
+#[test]
 fn can_add_trailers_to_a_commit_without_existing_trailers() {
     let commit = CommitMessage::from(indoc!(
             "

--- a/src/trailers.rs
+++ b/src/trailers.rs
@@ -178,6 +178,7 @@ impl<'a> From<Trailers<'a>> for String {
 impl<'a> From<Vec<Fragment<'a>>> for Trailers<'a> {
     fn from(ast: Vec<Fragment<'a>>) -> Self {
         ast.into_iter()
+            .skip(1)
             .filter_map(|values| {
                 if let Fragment::Body(body) = values {
                     Some(body)

--- a/src/trailers_test.rs
+++ b/src/trailers_test.rs
@@ -120,3 +120,31 @@ fn it_can_be_constructed_from_ast() {
 
     assert_eq!(Trailers::from(trailers), expected);
 }
+
+#[test]
+fn it_can_be_constructed_from_ast_with_conventional_commits() {
+    let trailers = vec![
+        Fragment::Body(Body::from("feat: Example Commit")),
+        Fragment::Body(Body::default()),
+        Fragment::Body(Body::from(
+            "Co-authored-by: Billie Thompson <billie@example.com>",
+        )),
+        Fragment::Body(Body::from(
+            "Co-authored-by: Somebody Else <somebody@example.com>",
+        )),
+    ];
+
+    let expected: Trailers<'_> = vec![
+        Trailer::new(
+            "Co-authored-by".into(),
+            "Billie Thompson <billie@example.com>".into(),
+        ),
+        Trailer::new(
+            "Co-authored-by".into(),
+            "Somebody Else <somebody@example.com>".into(),
+        ),
+    ]
+    .into();
+
+    assert_eq!(Trailers::from(trailers), expected);
+}


### PR DESCRIPTION
This PR is intended to resolve (https://github.com/PurpleBooth/mit-commit/issues/111).

The proposed solution is to simply skip the subject line of bodies when parsing trailers from ast